### PR TITLE
Add label to deployments that will switch

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -255,6 +255,11 @@ ul.small {
   padding: 2px 10px 5px 10px;
 }
 
+.label-switching {
+  background-color: #9ee4ff;
+  color: rgb(0 0 0);
+}
+
 .label-healthy {
   background-color: #d2ffcc;
   color: rgb(0, 129, 0);

--- a/ui/components/deploymentItem.js
+++ b/ui/components/deploymentItem.js
@@ -58,7 +58,10 @@ function deploymentItem (vnode) {
             ? html`<a href="https://${service.domain}" target="_blank">visit</a>`
             : html`<a href="https://${deployment.title}--${service.domain}" target="_blank">visit</a>`})
         </div>
-        <div class="nowrap cutoff">${deployment.branch}</div>
+        <div class="nowrap cutoff">${deployment.branch || 'unknown'}</div>
+        ${deployment.autoSwitch ? html`<div class="nowrap cutoff">
+          <span class="label label-switching">switching</span>
+        </div>` : ''}
         <div><span class="label label-${deployment.status}">${deployment.healthyInstances}/${deployment.totalInstances} Instances</span></div>
         <div>
           ${m(mui.dropdown, { class: 'align-right', head: '☰' }, [


### PR DESCRIPTION
This PR adds a a label to deployments that will auto switch.

<img width="831" alt="Screen Shot 2020-10-25 at 5 19 28 pm" src="https://user-images.githubusercontent.com/5929807/97101126-5805db00-16e6-11eb-99aa-2081dbccae2a.png">
